### PR TITLE
with no content response, send appropriate headers

### DIFF
--- a/src/main/java/express/http/response/Response.java
+++ b/src/main/java/express/http/response/Response.java
@@ -369,13 +369,15 @@ public class Response {
 
     private void sendHeaders() {
         try {
+            boolean hasContent = this.contentLength != 0;
+            if (hasContent) {
+                // Fallback
+                String contentType = getContentType() == null ? MediaType._bin.getExtension() : getContentType();
 
-            // Fallback
-            String contentType = getContentType() == null ? MediaType._bin.getExtension() : getContentType();
-
-            // Set header and send response
-            this.headers.set("Content-Type", contentType);
-            this.httpExchange.sendResponseHeaders(status, contentLength);
+                // Set header and send response
+                this.headers.set("Content-Type", contentType);
+            }
+            this.httpExchange.sendResponseHeaders(status, (hasContent) ? contentLength : -1);
         } catch (IOException e) {
             log.error("Failed to send headers.", e);
         }


### PR DESCRIPTION
With this change, when there is an empty response body, the Response class will send a Content-Length:0 header, and will not send Content-Encoding and Content-Type headers. Previously, the Response class would send no Content-Length header and would send a Content-Encoding and a Content-Type header, neither of which is particularly appropriate with no response body.

For example, for a 302 response, 
old behavior: 
```
HTTP/1.1 302 Temporary Redirect
Date: Thu, 15 Jun 2023 21:25:53 GMT
Transfer-encoding: chunked
Content-type: text/plain
Location: /.well-known/foo.bar
```

new behavior:
```
HTTP/1.1 302 Temporary Redirect
Date: Thu, 15 Jun 2023 21:23:15 GMT
Content-length: 0
Location: /.well-known/foo.bar
```
